### PR TITLE
Replace deprecated deps from npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ Sessions are removed when Claude Code fires `SessionEnd`, or automatically after
 
 Hover over a dot to see the project folder and status. Hover anywhere on the widget to see all active project names.
 
+## Dependencies
+
+- **boolean**: Replaced with a local shim (`patches/boolean-shim`) via `overrides` so the deprecated `boolean` package is not installed. The shim matches the same API (`boolean`, `isBooleanable`).
+- **glob / inflight**: These come from **Jest** (and related packages). Jest 29 still uses `glob@7`, which depends on deprecated `inflight`. You may see npm deprecation warnings; they are harmless. Upgrading to `glob@10` would require Jest to use the new API (see [jestjs/jest#15173](https://github.com/jestjs/jest/issues/15173), [#15910](https://github.com/jestjs/jest/issues/15910)). Until Jest updates, the warnings can be ignored or suppressed.
+
 ## Development
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "peon-pet",
-  "version": "0.1.0",
+  "version": "1.0.0-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "peon-pet",
-      "version": "0.1.0",
+      "version": "1.0.0-alpha.1",
       "dependencies": {
         "three": "^0.183.0"
       },
@@ -1376,13 +1376,8 @@
       }
     },
     "node_modules/boolean": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
-      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
+      "resolved": "node_modules/global-agent/patches/boolean-shim",
+      "link": true
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
@@ -2374,6 +2369,10 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/global-agent/patches/boolean-shim": {
+      "dev": true,
+      "optional": true
     },
     "node_modules/globalthis": {
       "version": "1.0.4",
@@ -3602,9 +3601,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -4203,6 +4202,14 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/roarr/node_modules/boolean": {
+      "resolved": "node_modules/roarr/patches/boolean-shim",
+      "link": true
+    },
+    "node_modules/roarr/patches/boolean-shim": {
+      "dev": true,
+      "optional": true
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",

--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
     "canvas": "^3.2.1",
     "electron": "^40.4.1",
     "jest": "^29.7.0"
+  },
+  "overrides": {
+    "boolean": "file:./patches/boolean-shim"
   }
 }

--- a/patches/boolean-shim/index.js
+++ b/patches/boolean-shim/index.js
@@ -1,0 +1,47 @@
+'use strict';
+
+// Drop-in replacement for deprecated "boolean" package (same API).
+// Truthy: true, 'true', 't', 'yes', 'y', 'on', '1', 1 (and trimmed string variants).
+// All other values (including undefined, null) => false.
+const TRUTHY = new Set([
+  true, 'true', 't', 'yes', 'y', 'on', '1',
+  'TRUE', 'T', 'YES', 'Y', 'ON'
+]);
+
+// Booleanable = truthy set + falsy strings/numbers.
+const FALSY_STRINGS = new Set([
+  false, 'false', 'f', 'no', 'n', 'off', '0',
+  'FALSE', 'F', 'NO', 'N', 'OFF'
+]);
+
+function parse(value) {
+  if (value === true || value === 1) return true;
+  if (value === undefined || value === null) return false;
+  if (typeof value === 'string') {
+    const s = value.trim();
+    return TRUTHY.has(s) || (s === '1');
+  }
+  if (typeof value === 'number') return value === 1;
+  if (typeof value === 'object' && value !== null) {
+    const s = String(value).trim();
+    return TRUTHY.has(s) || s === '1';
+  }
+  return false;
+}
+
+function isBooleanable(value) {
+  if (value === true || value === 1 || value === false || value === 0) return true;
+  if (value === undefined || value === null) return false;
+  if (typeof value === 'string') {
+    const s = value.trim();
+    return TRUTHY.has(s) || FALSY_STRINGS.has(s) || s === '0' || s === '1';
+  }
+  if (typeof value === 'number') return true;
+  if (typeof value === 'object' && value !== null) {
+    const s = String(value).trim();
+    return TRUTHY.has(s) || FALSY_STRINGS.has(s) || s === '0' || s === '1';
+  }
+  return false;
+}
+
+module.exports = { boolean: parse, isBooleanable };

--- a/patches/boolean-shim/package.json
+++ b/patches/boolean-shim/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "boolean",
+  "version": "3.2.0-shim.1",
+  "description": "Drop-in replacement for deprecated boolean package - parses values to boolean",
+  "main": "index.js",
+  "license": "MIT"
+}


### PR DESCRIPTION
The following packages have been updated or replaced:

- boolean shim
- document glob/inflight
- minimatch audit fix