### PR TITLE
feat: add drag-to-move and configurable starting corner

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,3 +114,11 @@ To switch back to the default orc:
 { "character": "orc" }
 ```
 Or just delete `peon-pet-config.json`.
+
+### Window Corner
+
+Set the starting corner of the pet window in `peon-pet-config.json`:
+```json
+{ "corner": "bottom-right" }
+```
+Values: `"bottom-left"` (default), `"bottom-right"`, `"top-left"`, `"top-right"`.

--- a/lib/window-position.js
+++ b/lib/window-position.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const WIN_SIZE = 200;
+const WIN_MARGIN = 20;
+
+function cornerPosition(corner, width, height) {
+  const right = width - WIN_SIZE - WIN_MARGIN;
+  const bottom = height - WIN_SIZE - WIN_MARGIN;
+  switch (corner) {
+    case 'top-left':     return { x: WIN_MARGIN, y: WIN_MARGIN };
+    case 'top-right':    return { x: right,      y: WIN_MARGIN };
+    case 'bottom-right': return { x: right,      y: bottom };
+    default:             return { x: WIN_MARGIN, y: bottom }; // bottom-left
+  }
+}
+
+module.exports = { WIN_SIZE, WIN_MARGIN, cornerPosition };

--- a/main.js
+++ b/main.js
@@ -252,19 +252,7 @@ function buildDockMenu() {
   ]);
 }
 
-const WIN_SIZE = 200;
-const WIN_MARGIN = 20;
-
-function cornerPosition(corner, width, height) {
-  const right = width - WIN_SIZE - WIN_MARGIN;
-  const bottom = height - WIN_SIZE - WIN_MARGIN;
-  switch (corner) {
-    case 'top-left':     return { x: WIN_MARGIN, y: WIN_MARGIN };
-    case 'top-right':    return { x: right,      y: WIN_MARGIN };
-    case 'bottom-right': return { x: right,      y: bottom };
-    default:             return { x: WIN_MARGIN, y: bottom }; // bottom-left
-  }
-}
+const { WIN_SIZE, WIN_MARGIN, cornerPosition } = require('./lib/window-position');
 
 function createWindow() {
   const { width, height } = screen.getPrimaryDisplay().workAreaSize;

--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, screen, Menu, protocol, net } = require('electron');
+const { app, BrowserWindow, screen, Menu, protocol, net, ipcMain } = require('electron');
 const path = require('path');
 const fs = require('fs');
 const os = require('os');
@@ -178,16 +178,52 @@ function startPolling() {
   }, 200);
 }
 
+// --- Drag state ---
+let isDragging = false;
+let dragOffsetX = 0;
+let dragOffsetY = 0;
+let ignoringMouse = true;  // tracks last setIgnoreMouseEvents value
+
+ipcMain.on('drag-start', () => {
+  if (!win || win.isDestroyed()) return;
+  isDragging = true;
+  const { x: cx, y: cy } = screen.getCursorScreenPoint();
+  const [wx, wy] = win.getPosition();
+  dragOffsetX = cx - wx;
+  dragOffsetY = cy - wy;
+  if (ignoringMouse) {
+    win.setIgnoreMouseEvents(false);
+    ignoringMouse = false;
+  }
+});
+
+ipcMain.on('drag-stop', () => {
+  isDragging = false;
+});
+
 // Poll cursor position to enable mouse events only when hovering the window.
 // This lets the renderer receive mousemove for tooltips while keeping click-through.
+// During drag, moves the window to follow the cursor.
 function startMouseTracking() {
   setInterval(() => {
     if (!win || win.isDestroyed()) return;
     const { x: cx, y: cy } = screen.getCursorScreenPoint();
+
+    if (isDragging) {
+      const nx = cx - dragOffsetX;
+      const ny = cy - dragOffsetY;
+      const [wx, wy] = win.getPosition();
+      if (nx !== wx || ny !== wy) win.setPosition(nx, ny);
+      return;
+    }
+
     const [wx, wy] = win.getPosition();
     const [ww, wh] = win.getSize();
     const inside = cx >= wx && cx <= wx + ww && cy >= wy && cy <= wy + wh;
-    win.setIgnoreMouseEvents(!inside);
+    if (inside !== !ignoringMouse) {
+      win.setIgnoreMouseEvents(!inside);
+      ignoringMouse = !inside;
+    }
   }, 50);
 }
 
@@ -216,14 +252,30 @@ function buildDockMenu() {
   ]);
 }
 
+const WIN_SIZE = 200;
+const WIN_MARGIN = 20;
+
+function cornerPosition(corner, width, height) {
+  const right = width - WIN_SIZE - WIN_MARGIN;
+  const bottom = height - WIN_SIZE - WIN_MARGIN;
+  switch (corner) {
+    case 'top-left':     return { x: WIN_MARGIN, y: WIN_MARGIN };
+    case 'top-right':    return { x: right,      y: WIN_MARGIN };
+    case 'bottom-right': return { x: right,      y: bottom };
+    default:             return { x: WIN_MARGIN, y: bottom }; // bottom-left
+  }
+}
+
 function createWindow() {
   const { width, height } = screen.getPrimaryDisplay().workAreaSize;
+  const cfg = loadPetConfig();
+  const { x, y } = cornerPosition(cfg.corner, width, height);
 
   win = new BrowserWindow({
-    width: 200,
-    height: 200,
-    x: 20,
-    y: height - 220,
+    width: WIN_SIZE,
+    height: WIN_SIZE,
+    x,
+    y,
     transparent: true,
     frame: false,
     alwaysOnTop: true,
@@ -256,6 +308,9 @@ function createWindow() {
   if (process.argv.includes('--dev')) {
     win.webContents.openDevTools({ mode: 'detach' });
   }
+
+  // Reset drag if renderer reloads or crashes
+  win.webContents.on('did-finish-load', () => { isDragging = false; });
 
   // Start polling once window is ready
   win.webContents.once('did-finish-load', () => {

--- a/preload.js
+++ b/preload.js
@@ -3,4 +3,6 @@ const { contextBridge, ipcRenderer } = require('electron');
 contextBridge.exposeInMainWorld('peonBridge', {
   onEvent: (callback) => ipcRenderer.on('peon-event', (_e, data) => callback(data)),
   onSessionUpdate: (callback) => ipcRenderer.on('session-update', (_e, data) => callback(data)),
+  startDrag: () => ipcRenderer.send('drag-start'),
+  stopDrag: () => ipcRenderer.send('drag-stop'),
 });

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -340,7 +340,38 @@ function hitTestDots(px, py) {
   return -1;
 }
 
+// --- Drag handling ---
+let dragging = false;
+
+canvas.addEventListener('pointerdown', (e) => {
+  if (e.button !== 0) return;  // left-click only
+  dragging = true;
+  tooltip.style.display = 'none';
+  canvas.setPointerCapture(e.pointerId);
+  window.peonBridge.startDrag();
+});
+
+canvas.addEventListener('pointerup', (e) => {
+  if (e.button !== 0 || !dragging) return;
+  dragging = false;
+  window.peonBridge.stopDrag();
+});
+
+canvas.addEventListener('lostpointercapture', () => {
+  if (!dragging) return;
+  dragging = false;
+  window.peonBridge.stopDrag();
+});
+
+canvas.addEventListener('pointercancel', () => {
+  if (!dragging) return;
+  dragging = false;
+  window.peonBridge.stopDrag();
+});
+
 canvas.addEventListener('mousemove', (e) => {
+  if (dragging) return;  // suppress tooltip during drag
+
   const px = e.offsetX;
   const py = e.offsetY;
   const idx = hitTestDots(px, py);
@@ -374,7 +405,7 @@ canvas.addEventListener('mousemove', (e) => {
 });
 
 canvas.addEventListener('mouseleave', () => {
-  tooltip.style.display = 'none';
+  if (!dragging) tooltip.style.display = 'none';
 });
 
 // --- IPC events ---

--- a/tests/window-position.test.js
+++ b/tests/window-position.test.js
@@ -1,0 +1,81 @@
+'use strict';
+
+const { WIN_SIZE, WIN_MARGIN, cornerPosition } = require('../lib/window-position');
+
+// ─── constants ────────────────────────────────────────────────────────────────
+
+describe('constants', () => {
+  test('WIN_SIZE is 200', () => {
+    expect(WIN_SIZE).toBe(200);
+  });
+
+  test('WIN_MARGIN is 20', () => {
+    expect(WIN_MARGIN).toBe(20);
+  });
+});
+
+// ─── cornerPosition ──────────────────────────────────────────────────────────
+
+describe('cornerPosition', () => {
+  const W = 1920;
+  const H = 1080;
+
+  test('bottom-left places window at left edge with margin', () => {
+    const { x, y } = cornerPosition('bottom-left', W, H);
+    expect(x).toBe(WIN_MARGIN);
+    expect(y).toBe(H - WIN_SIZE - WIN_MARGIN);
+  });
+
+  test('bottom-right places window at right edge with margin', () => {
+    const { x, y } = cornerPosition('bottom-right', W, H);
+    expect(x).toBe(W - WIN_SIZE - WIN_MARGIN);
+    expect(y).toBe(H - WIN_SIZE - WIN_MARGIN);
+  });
+
+  test('top-left places window at top-left with margin', () => {
+    const { x, y } = cornerPosition('top-left', W, H);
+    expect(x).toBe(WIN_MARGIN);
+    expect(y).toBe(WIN_MARGIN);
+  });
+
+  test('top-right places window at top-right with margin', () => {
+    const { x, y } = cornerPosition('top-right', W, H);
+    expect(x).toBe(W - WIN_SIZE - WIN_MARGIN);
+    expect(y).toBe(WIN_MARGIN);
+  });
+
+  test('defaults to bottom-left for undefined corner', () => {
+    const { x, y } = cornerPosition(undefined, W, H);
+    expect(x).toBe(WIN_MARGIN);
+    expect(y).toBe(H - WIN_SIZE - WIN_MARGIN);
+  });
+
+  test('defaults to bottom-left for unknown string', () => {
+    const { x, y } = cornerPosition('center', W, H);
+    expect(x).toBe(WIN_MARGIN);
+    expect(y).toBe(H - WIN_SIZE - WIN_MARGIN);
+  });
+
+  test('works with small screen (e.g. 800x600)', () => {
+    const { x, y } = cornerPosition('bottom-right', 800, 600);
+    expect(x).toBe(800 - WIN_SIZE - WIN_MARGIN);
+    expect(y).toBe(600 - WIN_SIZE - WIN_MARGIN);
+  });
+
+  test('all four corners return different positions on a non-square screen', () => {
+    const positions = ['top-left', 'top-right', 'bottom-left', 'bottom-right']
+      .map(c => cornerPosition(c, W, H));
+    const unique = new Set(positions.map(p => `${p.x},${p.y}`));
+    expect(unique.size).toBe(4);
+  });
+
+  test('window fits within screen bounds for all corners', () => {
+    for (const corner of ['top-left', 'top-right', 'bottom-left', 'bottom-right']) {
+      const { x, y } = cornerPosition(corner, W, H);
+      expect(x).toBeGreaterThanOrEqual(0);
+      expect(y).toBeGreaterThanOrEqual(0);
+      expect(x + WIN_SIZE).toBeLessThanOrEqual(W);
+      expect(y + WIN_SIZE).toBeLessThanOrEqual(H);
+    }
+  });
+});


### PR DESCRIPTION
Hey! Thanks for this ❤️ – I love Peon, it makes my work much more fun! I also ran into a similar issue like the one described here in #6. I want to be able to move my orc around, and this does the trick. I also added a way to configure this (using the config abstraction that's already in place).

Implements https://github.com/PeonPing/peon-pet/issues/6

## Summary

- **Drag-to-move**: Click and drag the pet window to reposition it anywhere on screen. Uses pointer capture in the renderer with IPC to the main process, which moves the window in the existing mouse-tracking poll loop.
- **Configurable starting corner**: New `corner` option in `peon-pet-config.json` to set which screen corner the window starts in (`bottom-left`, `bottom-right`, `top-left`, `top-right`). Defaults to `bottom-left`.

### Implementation details
- Drag offset calculated on `drag-start` for smooth, non-jumping movement
- `setIgnoreMouseEvents` only called on state change (avoids redundant Electron API calls)
- `win.setPosition` skipped when cursor hasn't moved (avoids no-op OS compositor work)
- Safety reset of drag state on renderer reload/crash
- Handles `pointerup`, `lostpointercapture`, and `pointercancel` for robust cleanup
- Extracted magic numbers into `WIN_SIZE` / `WIN_MARGIN` constants

## Test plan
- [ ] Launch app — window appears in bottom-left (default)
- [ ] Set `{ "corner": "top-right" }` in config, restart — window appears in top-right
- [ ] Test all four corner values
- [ ] Click and drag the pet — window follows cursor smoothly
- [ ] Release mouse — window stays in new position
- [ ] Drag near screen edges — no clipping issues
- [ ] Reload renderer (DevTools) mid-drag — drag cancels cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)