### PR TITLE
feat: replace peon-ping state-file polling with JSONL transcript watcher

### DIFF
--- a/lib/jsonl-watcher.js
+++ b/lib/jsonl-watcher.js
@@ -1,0 +1,350 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const EventEmitter = require('events');
+
+const PROJECTS_DIR = path.join(os.homedir(), '.claude', 'projects');
+const SCAN_INTERVAL_MS = 1000;
+const FILE_POLL_INTERVAL_MS = 500;
+const SESSION_PRUNE_MS = 10 * 60 * 1000; // skip files older than 10min on startup
+const PERMISSION_TIMEOUT_MS = 7000;
+const SUBAGENT_IDLE_MS = 5000;           // subagent window closes after 5s of no new content
+const PERMISSION_EXEMPT_TOOLS = new Set(['Task', 'Agent', 'AskUserQuestion']);
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function sessionIdFromPath(filePath) {
+  const base = path.basename(filePath, '.jsonl');
+  return UUID_RE.test(base) ? base : null;
+}
+
+/**
+ * Watches ~/.claude/projects/ for JSONL transcript files and emits events:
+ *
+ *   'session-event'  { sessionId, event, cwd, timestamp }
+ *     events: SessionStart | SessionSeen | SessionCwd | Stop |
+ *             UserPromptSubmit | PermissionRequest | PostToolUseFailure
+ *
+ *   'subagent-event' { sessionId, parentToolId, event }
+ *     events: SubagentStart | SubagentStop
+ *
+ * Two subagent mechanisms are detected:
+ *   - Foreground (sync) agents: agent_progress records in the main session JSONL
+ *   - Background agents: separate files at <session-id>/subagents/agent-<agentId>.jsonl
+ */
+class JsonlWatcher extends EventEmitter {
+  constructor() {
+    super();
+    this._fileStates = new Map();  // filePath → FileState
+    this._knownFiles = new Set();
+    this._scanInterval = null;
+    this._startupScanDone = false;
+  }
+
+  start() {
+    this._scan();
+    this._startupScanDone = true;
+    this._scanInterval = setInterval(() => this._scan(), SCAN_INTERVAL_MS);
+  }
+
+  // Returns session IDs that currently have unresolved tool_use calls
+  getActiveSessionIds() {
+    const active = new Set();
+    for (const state of this._fileStates.values()) {
+      if (!state.isSubagentFile && state.pendingTools.size > 0) {
+        active.add(state.sessionId);
+      }
+    }
+    return active;
+  }
+
+  stop() {
+    if (this._scanInterval) clearInterval(this._scanInterval);
+    for (const state of this._fileStates.values()) this._teardownFile(state);
+    this._fileStates.clear();
+    this._knownFiles.clear();
+  }
+
+  _scan() {
+    if (!fs.existsSync(PROJECTS_DIR)) return;
+    try {
+      const projectDirs = fs.readdirSync(PROJECTS_DIR, { withFileTypes: true })
+        .filter(d => d.isDirectory())
+        .map(d => path.join(PROJECTS_DIR, d.name));
+
+      for (const dir of projectDirs) {
+        let entries;
+        try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { continue; }
+
+        for (const entry of entries) {
+          if (entry.isFile() && entry.name.endsWith('.jsonl')) {
+            this._registerFile(path.join(dir, entry.name));
+          } else if (entry.isDirectory() && UUID_RE.test(entry.name)) {
+            // Session subdirectory — scan for background subagent files
+            this._scanSubagentsDir(path.join(dir, entry.name, 'subagents'), entry.name);
+          }
+        }
+      }
+    } catch {}
+  }
+
+  _scanSubagentsDir(subagentsDir, parentSessionId) {
+    let files;
+    try { files = fs.readdirSync(subagentsDir); } catch { return; }
+    for (const f of files) {
+      if (!f.startsWith('agent-') || !f.endsWith('.jsonl')) continue;
+      const filePath = path.join(subagentsDir, f);
+      if (this._knownFiles.has(filePath)) continue;
+      this._knownFiles.add(filePath);
+      const agentId = f.slice('agent-'.length, -'.jsonl'.length);
+      this._watchSubagentFile(filePath, parentSessionId, agentId);
+    }
+  }
+
+  _registerFile(filePath) {
+    if (this._knownFiles.has(filePath)) return;
+    this._knownFiles.add(filePath);
+    this._watchFile(filePath);
+  }
+
+  _watchFile(filePath) {
+    const sessionId = sessionIdFromPath(filePath);
+    if (!sessionId) return;
+
+    const isStartup = !this._startupScanDone;
+    let fileMtime;
+    try { fileMtime = fs.statSync(filePath).mtimeMs; } catch { return; }
+
+    // Skip stale files during startup
+    if (isStartup && (Date.now() - fileMtime) > SESSION_PRUNE_MS) return;
+
+    const state = {
+      sessionId,
+      filePath,
+      lineBuffer: '',
+      offset: 0,
+      fsWatcher: null,
+      pollInterval: null,
+      staleTimer: null,
+      cwd: null,
+      pendingTools: new Set(),
+      permissionTimer: null,
+      activeSubagentToolIds: new Set(),
+    };
+
+    this.emit('session-event', {
+      sessionId,
+      event: isStartup ? 'SessionSeen' : 'SessionStart',
+      cwd: null,
+      timestamp: isStartup ? fileMtime : Date.now(),
+    });
+
+    const readNew = () => this._readNewLines(state);
+    try { state.fsWatcher = fs.watch(filePath, readNew); } catch {}
+    state.pollInterval = setInterval(readNew, FILE_POLL_INTERVAL_MS);
+    this._fileStates.set(filePath, state);
+    readNew();
+  }
+
+  _watchSubagentFile(filePath, parentSessionId, agentId) {
+    const isStartup = !this._startupScanDone;
+    let fileMtime;
+    try { fileMtime = fs.statSync(filePath).mtimeMs; } catch { return; }
+
+    // Skip stale subagent files on startup
+    if (isStartup && (Date.now() - fileMtime) > SESSION_PRUNE_MS) return;
+
+    const parentToolId = `bg_${agentId}`;
+
+    const state = {
+      sessionId: parentSessionId,
+      filePath,
+      lineBuffer: '',
+      offset: 0,
+      fsWatcher: null,
+      pollInterval: null,
+      staleTimer: null,
+      parentToolId,
+      isSubagentFile: true,
+    };
+
+    this.emit('subagent-event', { sessionId: parentSessionId, parentToolId, event: 'SubagentStart' });
+
+    const resetStaleTimer = () => {
+      if (state.staleTimer) clearTimeout(state.staleTimer);
+      state.staleTimer = setTimeout(() => {
+        this.emit('subagent-event', { sessionId: parentSessionId, parentToolId, event: 'SubagentStop' });
+        this._teardownFile(state);
+        this._fileStates.delete(filePath);
+      }, SUBAGENT_IDLE_MS);
+    };
+
+    const readNew = () => {
+      const hadNew = this._readNewLines(state);
+      if (hadNew) resetStaleTimer();
+    };
+
+    try { state.fsWatcher = fs.watch(filePath, readNew); } catch {}
+    state.pollInterval = setInterval(readNew, FILE_POLL_INTERVAL_MS);
+    this._fileStates.set(filePath, state);
+    readNew();
+    resetStaleTimer();
+  }
+
+  _teardownFile(state) {
+    try { state.fsWatcher?.close(); } catch {}
+    if (state.pollInterval) clearInterval(state.pollInterval);
+    if (state.permissionTimer) clearTimeout(state.permissionTimer);
+    if (state.staleTimer) clearTimeout(state.staleTimer);
+  }
+
+  // Returns true if new bytes were read
+  _readNewLines(state) {
+    let buf;
+    try {
+      const fd = fs.openSync(state.filePath, 'r');
+      const size = fs.fstatSync(fd).size;
+      if (size <= state.offset) { fs.closeSync(fd); return false; }
+      buf = Buffer.alloc(size - state.offset);
+      fs.readSync(fd, buf, 0, buf.length, state.offset);
+      state.offset = size;
+      fs.closeSync(fd);
+    } catch { return false; }
+
+    const text = state.lineBuffer + buf.toString('utf8');
+    const lines = text.split('\n');
+    state.lineBuffer = lines.pop() || '';
+
+    for (const line of lines) {
+      if (line.trim()) this._processLine(line, state);
+    }
+    return true;
+  }
+
+  _processLine(line, state) {
+    let record;
+    try { record = JSON.parse(line); } catch { return; }
+
+    // Subagent files: only extract cwd, nothing else to track
+    if (state.isSubagentFile) {
+      if (!state.cwd && record.cwd) state.cwd = record.cwd;
+      return;
+    }
+
+    // Extract cwd from the first record that has it
+    if (!state.cwd && record.cwd) {
+      state.cwd = record.cwd;
+      this.emit('session-event', {
+        sessionId: state.sessionId,
+        event: 'SessionCwd',
+        cwd: record.cwd,
+        timestamp: Date.now(),
+      });
+    }
+
+    const now = Date.now();
+
+    switch (record.type) {
+      case 'system':
+        this._handleSystem(record, state, now);
+        break;
+      case 'assistant':
+        this._handleAssistant(record, state, now);
+        break;
+      case 'user':
+        this._handleUser(record, state, now);
+        break;
+      case 'progress':
+        this._handleProgress(record, state);
+        break;
+    }
+  }
+
+  _handleSystem(record, state, now) {
+    if (record.subtype === 'turn_duration') {
+      state.pendingTools.clear();
+      if (state.permissionTimer) {
+        clearTimeout(state.permissionTimer);
+        state.permissionTimer = null;
+      }
+
+      for (const parentToolId of state.activeSubagentToolIds) {
+        this.emit('subagent-event', { sessionId: state.sessionId, parentToolId, event: 'SubagentStop' });
+      }
+      state.activeSubagentToolIds.clear();
+
+      this.emit('session-event', { sessionId: state.sessionId, event: 'Stop', timestamp: now });
+    }
+  }
+
+  _handleAssistant(record, state, now) {
+    const content = record.message?.content;
+    if (!Array.isArray(content)) return;
+
+    const toolUses = content.filter(c => c.type === 'tool_use');
+    const hasActivity = toolUses.length > 0 || content.some(c => c.type === 'text' && c.text?.trim());
+
+    if (hasActivity) {
+      this.emit('session-event', { sessionId: state.sessionId, event: 'UserPromptSubmit', timestamp: now });
+    }
+
+    for (const tool of toolUses) {
+      if (!PERMISSION_EXEMPT_TOOLS.has(tool.name)) {
+        state.pendingTools.add(tool.id);
+      }
+    }
+
+    this._resetPermissionTimer(state);
+  }
+
+  _handleUser(record, state, now) {
+    const content = record.message?.content;
+    if (!Array.isArray(content)) return;
+
+    let hadFailure = false;
+    for (const item of content) {
+      if (item.type === 'tool_result') {
+        state.pendingTools.delete(item.tool_use_id);
+        if (item.is_error) hadFailure = true;
+      }
+    }
+
+    if (hadFailure) {
+      this.emit('session-event', { sessionId: state.sessionId, event: 'PostToolUseFailure', timestamp: now });
+    }
+
+    if (state.pendingTools.size === 0 && state.permissionTimer) {
+      clearTimeout(state.permissionTimer);
+      state.permissionTimer = null;
+    }
+  }
+
+  _handleProgress(record, state) {
+    const data = record.data || {};
+
+    // Foreground subagents: agent_progress records in the main session JSONL
+    if (data.type === 'agent_progress') {
+      const parentToolId = record.parentToolUseID || record.toolUseID;
+      if (parentToolId && !state.activeSubagentToolIds.has(parentToolId)) {
+        state.activeSubagentToolIds.add(parentToolId);
+        this.emit('subagent-event', { sessionId: state.sessionId, parentToolId, event: 'SubagentStart' });
+      }
+    }
+  }
+
+  _resetPermissionTimer(state) {
+    if (state.pendingTools.size === 0) return;
+    if (state.permissionTimer) return;
+
+    state.permissionTimer = setTimeout(() => {
+      state.permissionTimer = null;
+      if (state.pendingTools.size > 0) {
+        this.emit('session-event', { sessionId: state.sessionId, event: 'PermissionRequest', timestamp: Date.now() });
+      }
+    }, PERMISSION_TIMEOUT_MS);
+  }
+}
+
+module.exports = { JsonlWatcher };

--- a/main.js
+++ b/main.js
@@ -1,17 +1,16 @@
 const { app, BrowserWindow, screen, Menu, protocol, net, ipcMain } = require('electron');
 const path = require('path');
 const fs = require('fs');
-const os = require('os');
 const {
   isValidSessionId,
   createSessionTracker,
   buildSessionStates,
   EVENT_TO_ANIM,
 } = require('./lib/session-tracker');
+const { JsonlWatcher } = require('./lib/jsonl-watcher');
 
 let win;
 let petVisible = true;
-let lastPendingSubagentTs = 0; // tracks last seen pending_subagent_pack.ts to detect SubagentStart
 const subAgentWindows = new Map(); // session_id → BrowserWindow
 const subAgentCreatedAt = new Map(); // session_id → creation timestamp (ms)
 const dummySessionIds = new Set(); // dev-only: protected from sync cleanup
@@ -76,11 +75,6 @@ function registerCharacterProtocol() {
   return { char, assetsDir, customCharDir };
 }
 
-// Path to peon-ping state file
-const STATE_FILE = path.join(os.homedir(), '.claude', 'hooks', 'peon-ping', '.state.json');
-
-let lastTimestamp = 0;
-
 const tracker = createSessionTracker();
 const sessionCwds = new Map();  // session_id → cwd string
 const remoteSessionIds = new Set();
@@ -88,15 +82,6 @@ const remoteLastEvents = new Map();  // session_id → last event string
 const SESSION_PRUNE_MS = 10 * 60 * 1000;  // 10min — prune cold sessions
 const HOT_MS  = 30 * 1000;       // 30s  — actively working right now
 const WARM_MS = 2 * 60 * 1000;   // 2min — session open but idle
-
-function readStateFile() {
-  try {
-    const raw = fs.readFileSync(STATE_FILE, 'utf8');
-    return JSON.parse(raw);
-  } catch {
-    return null;
-  }
-}
 
 async function readRemoteState(baseUrl) {
   try {
@@ -179,80 +164,64 @@ function destroySubAgentWindow(sessionId) {
   repositionSubAgentWindows();
 }
 
-function syncSubAgentWindows(state) {
-  // TTL sweep: destroy windows that have been open too long (e.g. SubagentStop never fired)
-  const now = Date.now();
-  const expired = [...subAgentCreatedAt.entries()]
-    .filter(([sid, createdAt]) => now - createdAt > SUB_AGENT_TTL_MS && !dummySessionIds.has(sid))
-    .map(([sid]) => sid);
-  for (const sid of expired) destroySubAgentWindow(sid);
+function handleSessionEvent({ sessionId, event, cwd, timestamp }) {
+  if (!isValidSessionId(sessionId)) return;
 
-  // Detect SubagentStart: pending_subagent_pack.ts is updated by peon.sh on each SubagentStart
-  const pendingPack = state.pending_subagent_pack;
-  if (pendingPack?.ts > lastPendingSubagentTs) {
-    lastPendingSubagentTs = pendingPack.ts;
-    createSubAgentWindow(`peon_sub_${Math.round(pendingPack.ts * 1000)}`);
+  const now = Date.now();
+
+  // SessionCwd: just update the display name, no tracker change
+  if (event === 'SessionCwd') {
+    if (cwd) {
+      sessionCwds.set(sessionId, cwd);
+      sendSessionUpdate(now);
+    }
+    return;
   }
-}
 
-function initLastPendingSubagentTs() {
-  const state = readStateFile();
-  const ts = state?.pending_subagent_pack?.ts;
-  if (ts) lastPendingSubagentTs = ts;
-}
-
-function processStateUpdate(state, lastTs, setLastTs) {
-  if (!state || !state.last_active) return lastTs;
-
-  const { timestamp, event, session_id, cwd } = state.last_active;
-  if (timestamp === lastTs) return lastTs;
-  setLastTs(timestamp);
-
-  const now = Date.now();
-
-  if (isValidSessionId(session_id)) {
-    if (event === 'SessionEnd') {
-      tracker.remove(session_id);
-      sessionCwds.delete(session_id);
-    } else {
-      // On SessionStart, deduplicate: if exactly one other session was seen
-      // within the last 5s, it's likely the same window transitioning to a
-      // resumed session (e.g. /resume in Claude Code) — replace it.
-      if (event === 'SessionStart') {
-        const existing = tracker.entries();
-        const isNew = !existing.some(([id]) => id === session_id);
-        if (isNew && existing.length === 1) {
-          const [oldId, oldTime] = existing[0];
-          if ((now - oldTime) < 5000) {
-            tracker.remove(oldId);
-          }
-        }
+  if (event === 'SessionEnd') {
+    tracker.remove(sessionId);
+    sessionCwds.delete(sessionId);
+  } else if (event === 'SessionSeen') {
+    // File existed at startup: register with actual file mtime, no animation, no dedup
+    tracker.update(sessionId, timestamp || now);
+    if (cwd) sessionCwds.set(sessionId, cwd);
+  } else {
+    if (event === 'SessionStart') {
+      // Deduplicate /resume: if exactly one session was seen <5s ago, replace it
+      const existing = tracker.entries();
+      const isNew = !existing.some(([id]) => id === sessionId);
+      if (isNew && existing.length === 1) {
+        const [oldId, oldTime] = existing[0];
+        if ((now - oldTime) < 5000) tracker.remove(oldId);
       }
-      tracker.update(session_id, now);
-      if (cwd) sessionCwds.set(session_id, cwd);
     }
-    tracker.prune(now - SESSION_PRUNE_MS);
-    // Keep sessionCwds in sync with tracker
-    for (const id of sessionCwds.keys()) {
-      if (!tracker.entries().some(([sid]) => sid === id)) sessionCwds.delete(id);
-    }
+    tracker.update(sessionId, now);
+    if (cwd) sessionCwds.set(sessionId, cwd);
   }
 
-  if (win && !win.isDestroyed()) {
-    const sessions = buildSessionStates(tracker.entries(), now, HOT_MS, WARM_MS, 10);
-    const sessionsWithCwd = sessions.map(s => ({
-      ...s,
-      cwd: sessionCwds.get(s.id) || null,
-    }));
-    win.webContents.send('session-update', { sessions: sessionsWithCwd });
+  tracker.prune(now - SESSION_PRUNE_MS);
+  for (const id of sessionCwds.keys()) {
+    if (!tracker.entries().some(([sid]) => sid === id)) sessionCwds.delete(id);
   }
+
+  sendSessionUpdate(now);
 
   const anim = EVENT_TO_ANIM[event];
   if (anim && win && !win.isDestroyed()) {
     win.webContents.send('peon-event', { anim, event });
   }
+}
 
-  return timestamp;
+function sendSessionUpdate(now) {
+  if (!win || win.isDestroyed()) return;
+  const sessions = buildSessionStates(tracker.entries(), now, HOT_MS, WARM_MS, 10);
+  win.webContents.send('session-update', {
+    sessions: sessions.map(s => ({
+      ...s,
+      cwd: sessionCwds.get(s.id) || null,
+      name: sessionCwds.get(s.id) ? path.basename(sessionCwds.get(s.id)) : null,
+    })),
+  });
 }
 
 function syncRemoteSessionsToTracker(state) {
@@ -281,32 +250,44 @@ function syncRemoteSessionsToTracker(state) {
     }
   }
 
-  if (win && !win.isDestroyed()) {
-    const sessions = buildSessionStates(tracker.entries(), now, HOT_MS, WARM_MS, 10);
-    const sessionsWithCwd = sessions.map(s => ({ ...s, cwd: sessionCwds.get(s.id) || null }));
-    win.webContents.send('session-update', { sessions: sessionsWithCwd });
-  }
+  sendSessionUpdate(now);
 }
 
 function startPolling() {
-  initLastPendingSubagentTs();
   const cfg = loadPetConfig();
   const remoteUrl = cfg.remoteUrl || 'http://127.0.0.1:19998';
 
-  setInterval(async () => {
-    const state = readStateFile();
-    if (state) syncSubAgentWindows(state);
-    // Detect SubagentStop: each Stop event (SubagentStop maps to Stop in peon.sh)
-    // destroys the oldest pseudo sub-agent window. Parent's own final Stop is a no-op.
-    if (state?.last_active?.timestamp !== lastTimestamp && state?.last_active?.event === 'Stop') {
-      const oldest = [...subAgentWindows.keys()]
-        .filter(id => id.startsWith('peon_sub_') && !dummySessionIds.has(id))
-        .sort((a, b) => (subAgentCreatedAt.get(a) || 0) - (subAgentCreatedAt.get(b) || 0))[0];
-      if (oldest) destroySubAgentWindow(oldest);
+  const watcher = new JsonlWatcher();
+
+  watcher.on('session-event', handleSessionEvent);
+  watcher.on('subagent-event', ({ parentToolId, event }) => {
+    if (event === 'SubagentStart') createSubAgentWindow(parentToolId);
+    if (event === 'SubagentStop')  destroySubAgentWindow(parentToolId);
+  });
+
+  watcher.start();
+
+  // Heartbeat: refresh session hot/warm status so the pet correctly decays.
+  // Sessions with pending tools are kept hot so the pet stays awake during long tool runs.
+  // Also runs the TTL sweep for sub-agent windows whose SubagentStop never fired.
+  setInterval(() => {
+    const now = Date.now();
+    const expired = [...subAgentCreatedAt.entries()]
+      .filter(([sid, createdAt]) => now - createdAt > SUB_AGENT_TTL_MS && !dummySessionIds.has(sid))
+      .map(([sid]) => sid);
+    for (const sid of expired) destroySubAgentWindow(sid);
+
+    if (tracker.entries().length === 0) return;
+    for (const sessionId of watcher.getActiveSessionIds()) {
+      tracker.update(sessionId, now);
     }
-    processStateUpdate(state, lastTimestamp, (ts) => { lastTimestamp = ts; });
+    sendSessionUpdate(now);
+  }, 5000);
+
+  // Remote relay sync (less frequent, not time-critical)
+  setInterval(async () => {
     syncRemoteSessionsToTracker(await readRemoteState(remoteUrl));
-  }, 200);
+  }, 5000);
 }
 
 // --- Drag state ---

--- a/tests/jsonl-watcher.test.js
+++ b/tests/jsonl-watcher.test.js
@@ -1,0 +1,503 @@
+'use strict';
+
+const fs   = require('fs');
+const path = require('path');
+const os   = require('os');
+const { JsonlWatcher } = require('../lib/jsonl-watcher');
+
+const PROJECTS_DIR = path.join(os.homedir(), '.claude', 'projects');
+const PROJECT_DIR  = path.join(PROJECTS_DIR, 'proj');
+const SESSION_ID   = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+const NOW          = 1_700_000_000_000;
+const STALE_MTIME  = NOW - 11 * 60_000; // > 10 min old
+const FRESH_MTIME  = NOW - 5_000;
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function fakeDir(name)  { return { name, isDirectory: () => true,  isFile: () => false }; }
+function fakeFile(name) { return { name, isDirectory: () => false, isFile: () => true  }; }
+
+/**
+ * Wire up fs spies for a single-session project layout.
+ *
+ * PROJECTS_DIR/proj/<SESSION_ID>.jsonl           ← main session file
+ * PROJECTS_DIR/proj/<SESSION_ID>/subagents/...   ← optional bg subagent files
+ */
+function setupFs({ mtime = FRESH_MTIME, lines = [], subagentFiles = null } = {}) {
+  const buf = Buffer.from(
+    lines.length ? lines.map(l => JSON.stringify(l)).join('\n') + '\n' : '',
+    'utf8',
+  );
+  let consumed = false;
+
+  jest.spyOn(fs, 'existsSync').mockImplementation(p => p === PROJECTS_DIR);
+  jest.spyOn(fs, 'readdirSync').mockImplementation((dir) => {
+    if (dir === PROJECTS_DIR) return [fakeDir('proj')];
+    if (dir === PROJECT_DIR) {
+      const list = [fakeFile(`${SESSION_ID}.jsonl`)];
+      if (subagentFiles) list.push(fakeDir(SESSION_ID));
+      return list;
+    }
+    if (subagentFiles && dir === path.join(PROJECT_DIR, SESSION_ID, 'subagents')) {
+      return subagentFiles;
+    }
+    return [];
+  });
+  jest.spyOn(fs, 'statSync').mockReturnValue({ mtimeMs: mtime });
+  jest.spyOn(fs, 'watch').mockReturnValue({ close: jest.fn() });
+  jest.spyOn(fs, 'openSync').mockReturnValue(3);
+  jest.spyOn(fs, 'fstatSync').mockImplementation(() => ({
+    size: (consumed || !buf.length) ? 0 : buf.length,
+  }));
+  jest.spyOn(fs, 'readSync').mockImplementation((_fd, dst, dstOff, len, srcOff) => {
+    consumed = true;
+    buf.copy(dst, dstOff, srcOff, srcOff + len);
+    return len;
+  });
+  jest.spyOn(fs, 'closeSync').mockReturnValue();
+}
+
+function collect(watcher, eventName) {
+  const events = [];
+  watcher.on(eventName, e => events.push(e));
+  return events;
+}
+
+// ─── .claude/projects does not exist ─────────────────────────────────────────
+
+describe('when .claude/projects does not exist', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  test('start() does not throw', () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+    const w = new JsonlWatcher();
+    expect(() => { w.start(); w.stop(); }).not.toThrow();
+  });
+
+  test('no events are emitted', () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+    const w = new JsonlWatcher();
+    const sessionEvents = collect(w, 'session-event');
+    const subagentEvents = collect(w, 'subagent-event');
+    w.start();
+    w.stop();
+    expect(sessionEvents).toHaveLength(0);
+    expect(subagentEvents).toHaveLength(0);
+  });
+});
+
+// ─── Startup scan ─────────────────────────────────────────────────────────────
+
+describe('startup scan — SessionSeen', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  test('fresh file emits SessionSeen with the correct sessionId', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(NOW);
+    setupFs({ mtime: FRESH_MTIME });
+    const w = new JsonlWatcher();
+    const events = collect(w, 'session-event');
+    w.start();
+    w.stop();
+    const ev = events.find(e => e.event === 'SessionSeen');
+    expect(ev).toBeDefined();
+    expect(ev.sessionId).toBe(SESSION_ID);
+  });
+
+  test('SessionSeen carries the file mtime as timestamp', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(NOW);
+    setupFs({ mtime: FRESH_MTIME });
+    const w = new JsonlWatcher();
+    const events = collect(w, 'session-event');
+    w.start();
+    w.stop();
+    expect(events.find(e => e.event === 'SessionSeen').timestamp).toBe(FRESH_MTIME);
+  });
+
+  test('file older than 10 min is pruned and emits nothing', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(NOW);
+    setupFs({ mtime: STALE_MTIME });
+    const w = new JsonlWatcher();
+    const events = collect(w, 'session-event');
+    w.start();
+    w.stop();
+    expect(events).toHaveLength(0);
+  });
+
+  test('file exactly at the 10-min boundary is NOT pruned', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(NOW);
+    // > SESSION_PRUNE_MS, not >=, so exactly 10 min is still kept
+    setupFs({ mtime: NOW - 10 * 60_000 });
+    const w = new JsonlWatcher();
+    const events = collect(w, 'session-event');
+    w.start();
+    w.stop();
+    expect(events.some(e => e.event === 'SessionSeen')).toBe(true);
+  });
+});
+
+// ─── Live scan ────────────────────────────────────────────────────────────────
+
+describe('live scan — SessionStart', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+  });
+
+  test('new file appearing after startup emits SessionStart', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(NOW);
+    setupFs({ mtime: FRESH_MTIME });
+
+    const w = new JsonlWatcher();
+    w.start(); // startup scan registers SESSION_ID
+
+    const events = collect(w, 'session-event');
+
+    const ID2 = 'cccccccc-0000-0000-0000-000000000002';
+    // Make a second session visible on the next scan
+    jest.spyOn(fs, 'readdirSync').mockImplementation((dir) => {
+      if (dir === PROJECTS_DIR) return [fakeDir('proj')];
+      if (dir === PROJECT_DIR)  return [fakeFile(`${SESSION_ID}.jsonl`), fakeFile(`${ID2}.jsonl`)];
+      return [];
+    });
+
+    jest.advanceTimersByTime(1_000);
+    w.stop();
+
+    expect(events.some(e => e.event === 'SessionStart' && e.sessionId === ID2)).toBe(true);
+  });
+
+  test('already-known file does not emit SessionStart again on re-scan', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(NOW);
+    setupFs({ mtime: FRESH_MTIME });
+
+    const w = new JsonlWatcher();
+    w.start();
+
+    const events = collect(w, 'session-event');
+    jest.advanceTimersByTime(1_000); // same files visible
+    w.stop();
+
+    expect(events.some(e => e.event === 'SessionStart')).toBe(false);
+  });
+});
+
+// ─── UserPromptSubmit ─────────────────────────────────────────────────────────
+
+describe('line parsing — UserPromptSubmit', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  test('assistant record with tool_use content emits UserPromptSubmit', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(NOW);
+    setupFs({ lines: [{
+      type: 'assistant',
+      message: { content: [{ type: 'tool_use', id: 't1', name: 'Bash', input: {} }] },
+    }] });
+    const w = new JsonlWatcher();
+    const events = collect(w, 'session-event');
+    w.start();
+    w.stop();
+    expect(events.some(e => e.event === 'UserPromptSubmit')).toBe(true);
+  });
+
+  test('assistant record with non-empty text content emits UserPromptSubmit', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(NOW);
+    setupFs({ lines: [{
+      type: 'assistant',
+      message: { content: [{ type: 'text', text: 'Here is my plan.' }] },
+    }] });
+    const w = new JsonlWatcher();
+    const events = collect(w, 'session-event');
+    w.start();
+    w.stop();
+    expect(events.some(e => e.event === 'UserPromptSubmit')).toBe(true);
+  });
+
+  test('assistant record with whitespace-only text does NOT emit UserPromptSubmit', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(NOW);
+    setupFs({ lines: [{
+      type: 'assistant',
+      message: { content: [{ type: 'text', text: '   \n  ' }] },
+    }] });
+    const w = new JsonlWatcher();
+    const events = collect(w, 'session-event');
+    w.start();
+    w.stop();
+    expect(events.some(e => e.event === 'UserPromptSubmit')).toBe(false);
+  });
+
+  test('malformed JSON line is silently skipped', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(NOW);
+    const buf = Buffer.from('not-valid-json\n', 'utf8');
+    jest.spyOn(fs, 'existsSync').mockImplementation(p => p === PROJECTS_DIR);
+    jest.spyOn(fs, 'readdirSync').mockImplementation((dir) => {
+      if (dir === PROJECTS_DIR) return [fakeDir('proj')];
+      if (dir === PROJECT_DIR)  return [fakeFile(`${SESSION_ID}.jsonl`)];
+      return [];
+    });
+    jest.spyOn(fs, 'statSync').mockReturnValue({ mtimeMs: FRESH_MTIME });
+    jest.spyOn(fs, 'watch').mockReturnValue({ close: jest.fn() });
+    let consumed = false;
+    jest.spyOn(fs, 'openSync').mockReturnValue(3);
+    jest.spyOn(fs, 'fstatSync').mockImplementation(() => ({ size: consumed ? 0 : buf.length }));
+    jest.spyOn(fs, 'readSync').mockImplementation((_fd, dst, dstOff, len, srcOff) => {
+      consumed = true;
+      buf.copy(dst, dstOff, srcOff, srcOff + len);
+      return len;
+    });
+    jest.spyOn(fs, 'closeSync').mockReturnValue();
+
+    const w = new JsonlWatcher();
+    expect(() => { w.start(); w.stop(); }).not.toThrow();
+  });
+});
+
+// ─── Stop ─────────────────────────────────────────────────────────────────────
+
+describe('line parsing — Stop', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  test('system turn_duration record emits Stop', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(NOW);
+    setupFs({ lines: [{ type: 'system', subtype: 'turn_duration' }] });
+    const w = new JsonlWatcher();
+    const events = collect(w, 'session-event');
+    w.start();
+    w.stop();
+    expect(events.some(e => e.event === 'Stop' && e.sessionId === SESSION_ID)).toBe(true);
+  });
+
+  test('Stop clears active foreground subagents', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(NOW);
+    setupFs({ lines: [
+      { type: 'progress', parentToolUseID: 'ptool-1', data: { type: 'agent_progress' } },
+      { type: 'system', subtype: 'turn_duration' },
+    ] });
+    const w = new JsonlWatcher();
+    const subEvents = collect(w, 'subagent-event');
+    w.start();
+    w.stop();
+    expect(subEvents.some(e => e.event === 'SubagentStop' && e.parentToolId === 'ptool-1')).toBe(true);
+  });
+});
+
+// ─── PermissionRequest ────────────────────────────────────────────────────────
+
+describe('line parsing — PermissionRequest', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+  });
+
+  test('non-exempt tool pending for 7 s triggers PermissionRequest', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(NOW);
+    setupFs({ lines: [{
+      type: 'assistant',
+      message: { content: [{ type: 'tool_use', id: 'bash-1', name: 'Bash', input: {} }] },
+    }] });
+    const w = new JsonlWatcher();
+    const events = collect(w, 'session-event');
+    w.start();
+
+    expect(events.some(e => e.event === 'PermissionRequest')).toBe(false);
+    jest.advanceTimersByTime(7_000);
+    expect(events.some(e => e.event === 'PermissionRequest')).toBe(true);
+    w.stop();
+  });
+
+  test('exempt tools (Task / Agent / AskUserQuestion) never trigger PermissionRequest', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(NOW);
+    setupFs({ lines: [{
+      type: 'assistant',
+      message: { content: [
+        { type: 'tool_use', id: 'task-1',  name: 'Task',             input: {} },
+        { type: 'tool_use', id: 'agent-1', name: 'Agent',            input: {} },
+        { type: 'tool_use', id: 'ask-1',   name: 'AskUserQuestion',  input: {} },
+      ] },
+    }] });
+    const w = new JsonlWatcher();
+    const events = collect(w, 'session-event');
+    w.start();
+    jest.advanceTimersByTime(10_000);
+    w.stop();
+    expect(events.some(e => e.event === 'PermissionRequest')).toBe(false);
+  });
+
+  test('tool_result response cancels the pending permission timer', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(NOW);
+
+    // First read: assistant issues a tool call
+    const assistantRecord = {
+      type: 'assistant',
+      message: { content: [{ type: 'tool_use', id: 'bash-2', name: 'Bash', input: {} }] },
+    };
+    // Second read (after timer would fire): user returns tool_result
+    const userRecord = {
+      type: 'user',
+      message: { content: [{ type: 'tool_result', tool_use_id: 'bash-2', content: 'ok' }] },
+    };
+
+    const allContent = Buffer.from(
+      [assistantRecord, userRecord].map(r => JSON.stringify(r)).join('\n') + '\n',
+      'utf8',
+    );
+    let consumed = false;
+    jest.spyOn(fs, 'existsSync').mockImplementation(p => p === PROJECTS_DIR);
+    jest.spyOn(fs, 'readdirSync').mockImplementation((dir) => {
+      if (dir === PROJECTS_DIR) return [fakeDir('proj')];
+      if (dir === PROJECT_DIR)  return [fakeFile(`${SESSION_ID}.jsonl`)];
+      return [];
+    });
+    jest.spyOn(fs, 'statSync').mockReturnValue({ mtimeMs: FRESH_MTIME });
+    jest.spyOn(fs, 'watch').mockReturnValue({ close: jest.fn() });
+    jest.spyOn(fs, 'openSync').mockReturnValue(3);
+    jest.spyOn(fs, 'fstatSync').mockImplementation(() => ({ size: consumed ? 0 : allContent.length }));
+    jest.spyOn(fs, 'readSync').mockImplementation((_fd, dst, dstOff, len, srcOff) => {
+      consumed = true;
+      allContent.copy(dst, dstOff, srcOff, srcOff + len);
+      return len;
+    });
+    jest.spyOn(fs, 'closeSync').mockReturnValue();
+
+    const w = new JsonlWatcher();
+    const events = collect(w, 'session-event');
+    w.start();
+    jest.advanceTimersByTime(10_000); // past the 7 s window
+    w.stop();
+
+    // Tool result resolved the pending tool — no PermissionRequest
+    expect(events.some(e => e.event === 'PermissionRequest')).toBe(false);
+  });
+});
+
+// ─── Foreground subagent detection ───────────────────────────────────────────
+
+describe('subagent detection — foreground (agent_progress)', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  test('progress record with agent_progress emits SubagentStart', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(NOW);
+    setupFs({ lines: [{
+      type: 'progress',
+      parentToolUseID: 'ptool-fg-1',
+      toolUseID: 'tuse-1',
+      data: { type: 'agent_progress' },
+    }] });
+    const w = new JsonlWatcher();
+    const events = collect(w, 'subagent-event');
+    w.start();
+    w.stop();
+    const ev = events.find(e => e.event === 'SubagentStart');
+    expect(ev).toBeDefined();
+    expect(ev.sessionId).toBe(SESSION_ID);
+    expect(ev.parentToolId).toBe('ptool-fg-1');
+  });
+
+  test('falls back to toolUseID when parentToolUseID is absent', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(NOW);
+    setupFs({ lines: [{
+      type: 'progress',
+      toolUseID: 'tuse-fallback',
+      data: { type: 'agent_progress' },
+    }] });
+    const w = new JsonlWatcher();
+    const events = collect(w, 'subagent-event');
+    w.start();
+    w.stop();
+    expect(events.find(e => e.event === 'SubagentStart').parentToolId).toBe('tuse-fallback');
+  });
+
+  test('same parentToolUseID seen twice emits SubagentStart only once', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(NOW);
+    const rec = { type: 'progress', parentToolUseID: 'ptool-dup', data: { type: 'agent_progress' } };
+    setupFs({ lines: [rec, rec] });
+    const w = new JsonlWatcher();
+    const events = collect(w, 'subagent-event');
+    w.start();
+    w.stop();
+    expect(events.filter(e => e.event === 'SubagentStart')).toHaveLength(1);
+  });
+
+  test('SubagentStop is emitted for each active subagent on turn_duration', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(NOW);
+    setupFs({ lines: [
+      { type: 'progress', parentToolUseID: 'ptool-a', data: { type: 'agent_progress' } },
+      { type: 'progress', parentToolUseID: 'ptool-b', data: { type: 'agent_progress' } },
+      { type: 'system', subtype: 'turn_duration' },
+    ] });
+    const w = new JsonlWatcher();
+    const events = collect(w, 'subagent-event');
+    w.start();
+    w.stop();
+    const stops = events.filter(e => e.event === 'SubagentStop').map(e => e.parentToolId);
+    expect(stops).toContain('ptool-a');
+    expect(stops).toContain('ptool-b');
+  });
+});
+
+// ─── Background subagent detection ───────────────────────────────────────────
+
+describe('subagent detection — background (subagents/ dir)', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+  });
+
+  test('agent-xxx.jsonl file emits SubagentStart with bg_ prefix', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(NOW);
+    setupFs({ subagentFiles: ['agent-abc123.jsonl'] });
+    const w = new JsonlWatcher();
+    const events = collect(w, 'subagent-event');
+    w.start();
+    w.stop();
+    const ev = events.find(e => e.event === 'SubagentStart');
+    expect(ev).toBeDefined();
+    expect(ev.sessionId).toBe(SESSION_ID);
+    expect(ev.parentToolId).toBe('bg_abc123');
+  });
+
+  test('subagent emits SubagentStop after 5 s of inactivity', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(NOW);
+    setupFs({ subagentFiles: ['agent-idle.jsonl'] });
+    const w = new JsonlWatcher();
+    const events = collect(w, 'subagent-event');
+    w.start();
+
+    expect(events.some(e => e.event === 'SubagentStop')).toBe(false);
+    jest.advanceTimersByTime(5_000);
+    expect(events.some(e => e.event === 'SubagentStop')).toBe(true);
+    // watcher.stop() not needed — teardown already happened inside timer callback
+  });
+
+  test('non-matching files in subagents/ are ignored', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(NOW);
+    setupFs({ subagentFiles: ['README.txt', 'agent-valid.jsonl', 'not-an-agent.jsonl'] });
+    const w = new JsonlWatcher();
+    const events = collect(w, 'subagent-event');
+    w.start();
+    w.stop();
+    const starts = events.filter(e => e.event === 'SubagentStart');
+    expect(starts).toHaveLength(1);
+    expect(starts[0].parentToolId).toBe('bg_valid');
+  });
+
+  test('stale background subagent file (>10 min) is pruned on startup', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(NOW);
+    // statSync returns stale mtime for both the session file and the subagent file
+    jest.spyOn(Date, 'now').mockReturnValue(NOW);
+    setupFs({ mtime: STALE_MTIME, subagentFiles: ['agent-old.jsonl'] });
+    const w = new JsonlWatcher();
+    const events = collect(w, 'subagent-event');
+    w.start();
+    w.stop();
+    expect(events.some(e => e.event === 'SubagentStart')).toBe(false);
+  });
+});


### PR DESCRIPTION
Reads Claude Code JSONL transcript files directly instead of relying on peon-ping shell hooks to write a state file. This decouples peon-pet from the external peon-ping dependency, inspired by [pixel-agents](https://github.com/pablodelucca/pixel-agents) approach.

- Add lib/jsonl-watcher.js: watches ~/.claude/projects for JSONL session transcript files and emits session-event / subagent-event as they stream
- Replace readStateFile/processStateUpdate polling loop with JsonlWatcher
- Replace 200ms setInterval with event-driven session tracking
- Add heartbeat interval to refresh hot/warm decay for long-running tools
- Remote relay sync kept as a 5s interval (unchanged behavior)